### PR TITLE
[feat / setup] reset.css 설정 및 글로벌 스타일 적용

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,15 @@
-import "./App.css";
+import reset from "style/reset.js";
+import { Global } from "@emotion/react";
+
+import UserInput from "components/body/UserInput";
 
 function App() {
-  return <div></div>;
+  return (
+    <>
+      <Global styles={reset} />
+      <UserInput />
+    </>
+  );
 }
 
 export default App;

--- a/src/common/SortedOutputBox.jsx
+++ b/src/common/SortedOutputBox.jsx
@@ -1,5 +1,5 @@
-function SortedOutputBox() {
+const SortedOutputBox = () => {
   return <div></div>;
-}
+};
 
 export default SortedOutputBox;

--- a/src/common/UTCTimer.jsx
+++ b/src/common/UTCTimer.jsx
@@ -1,5 +1,5 @@
-function UTCTimer() {
+const UTCTimer = () => {
   return <div></div>;
-}
+};
 
 export default UTCTimer;

--- a/src/components/body/UserInput.jsx
+++ b/src/components/body/UserInput.jsx
@@ -1,0 +1,34 @@
+import styled from "@emotion/styled";
+
+const UserInput = () => {
+  return (
+    <UserInputLayout>
+      <UserInputBox />
+      <UserInputSubmitButton>Enter</UserInputSubmitButton>
+    </UserInputLayout>
+  );
+};
+
+const UserInputLayout = styled.div`
+  display: flex;
+  width: 800px;
+  border: 1px solid black;
+`;
+
+const UserInputBox = styled.input`
+  width: 70%;
+  height: 40px;
+  margin: 1rem;
+  border: none;
+  border-bottom: 1px solid black;
+`;
+
+const UserInputSubmitButton = styled.button`
+  width: 20%;
+  height: 40px;
+  margin: 1rem;
+  cursor: pointer;
+  border: 1px solid black;
+`;
+
+export default UserInput;

--- a/src/components/header/Header.jsx
+++ b/src/components/header/Header.jsx
@@ -1,5 +1,5 @@
-function Header() {
+const Header = () => {
   return <div></div>;
-}
+};
 
 export default Header;

--- a/src/style/reset.js
+++ b/src/style/reset.js
@@ -1,0 +1,29 @@
+import { css } from "@emotion/react";
+
+const reset = css`
+  * {
+    padding: 0;
+    margin: 0;
+    box-sizing: border-box;
+  }
+  a {
+    text-decoration: none;
+    color: #333;
+    cursor: pointer;
+  }
+  li {
+    list-style: none;
+  }
+  button {
+    border: none;
+    background: none;
+  }
+  em {
+    font-style: normal;
+  }
+  input: focus {
+    outline: none;
+  }
+`;
+
+export default reset;


### PR DESCRIPTION
- [x] reset.css 설정 + Global로 적용
- [x] header 와 body 디렉토리 추가, 하위 컴포넌트 분리 
- [x] 모든 컴포넌트 화살표 함수로 형식 정정 / 통일



-----

페이지는 하나지만 Header에 비해 상대적으로 Body가 하위 컴포넌트를 상당히 많이 가지고 있는 것 같아서
조금이라도 나눠볼 심산으로 `header`랑 `body`로 나눠 놓은 상태입니다! 
추후에 더 나은 방법이 있으면 정정해도 좋을 것 같네요 :)